### PR TITLE
Fix custom HTTP client initialization

### DIFF
--- a/lib/src/xtream_code_client.dart
+++ b/lib/src/xtream_code_client.dart
@@ -108,7 +108,7 @@ class XtreamCode {
     String password,
     Client? httpClient,
   ) {
-    _httpClient = http_factory.httpClient();
+    _httpClient = httpClient ?? http_factory.httpClient();
     client = XtreamCodeClient(
       _createBaseUrl(url, port, username, password),
       _createStreamUrl(url, port, username, password),


### PR DESCRIPTION
## Summary
- use provided HTTP client in XtreamCode initialization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684002128508832c8e458e8963b89fda