### PR TITLE
Add list converters

### DIFF
--- a/lib/src/model/live_stream_items.dart
+++ b/lib/src/model/live_stream_items.dart
@@ -76,7 +76,7 @@ class XTremeCodeLiveStreamItem {
   final int? categoryId;
 
   /// The IDs of the categories.
-  @JsonKey(name: 'category_ids')
+  @JsonKey(name: 'category_ids', fromJson: intListFromJson)
   final List<int>? categoryIds;
 
   /// The thumbnail of the live stream item.

--- a/lib/src/model/live_stream_items.g.dart
+++ b/lib/src/model/live_stream_items.g.dart
@@ -21,9 +21,7 @@ XTremeCodeLiveStreamItem _$XTremeCodeLiveStreamItemFromJson(
       directSource: json['direct_source'] as String?,
       tvArchiveDuration: dynamicToIntConverter(json['tv_archive_duration']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds: (json['category_ids'] as List<dynamic>?)
-          ?.map((e) => (e as num).toInt())
-          .toList(),
+      categoryIds: intListFromJson(json['category_ids']),
       thumbnail: json['thumbnail'] as String?,
     );
 

--- a/lib/src/model/series_info.dart
+++ b/lib/src/model/series_info.dart
@@ -156,7 +156,7 @@ class XTremeCodeInfo {
   final double? rating5based;
 
   /// The backdrop path of the series.
-  @JsonKey(name: 'backdrop_path')
+  @JsonKey(name: 'backdrop_path', fromJson: stringListFromJson)
   final List<String>? backdropPath;
 
   /// The YouTube trailer of the series.
@@ -172,7 +172,7 @@ class XTremeCodeInfo {
   final int? categoryId;
 
   /// The IDs of the categories of the series.
-  @JsonKey(name: 'category_ids')
+  @JsonKey(name: 'category_ids', fromJson: intListFromJson)
   final List<int>? categoryIds;
 
   /// Converts this instance into a JSON object.
@@ -219,6 +219,7 @@ class XTremeCodeEpisode {
   final XTremeCodeEpisodeInfo info;
 
   /// The subtitles of the episode.
+  @JsonKey(fromJson: stringListFromJson)
   final List<String>? subtitles;
 
   /// The custom SID of the episode.

--- a/lib/src/model/series_info.g.dart
+++ b/lib/src/model/series_info.g.dart
@@ -71,17 +71,13 @@ XTremeCodeInfo _$XTremeCodeInfoFromJson(Map<String, dynamic> json) =>
       lastModified: dateTimeFromEpochSeconds(json['last_modified']),
       rating: dynamicToDoubleConverter(json['rating']),
       rating5based: dynamicToDoubleConverter(json['rating_5based']),
-      backdropPath: (json['backdrop_path'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          const [],
+      backdropPath:
+              stringListFromJson(json['backdrop_path']) ?? const [],
       youtubeTrailer: json['youtube_trailer'] as String?,
       episodeRunTime: dynamicToIntConverter(json['episode_run_time']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds: (json['category_ids'] as List<dynamic>?)
-              ?.map((e) => (e as num).toInt())
-              .toList() ??
-          const [],
+      categoryIds:
+              intListFromJson(json['category_ids']) ?? const [],
     );
 
 Map<String, dynamic> _$XTremeCodeInfoToJson(XTremeCodeInfo instance) =>
@@ -113,9 +109,7 @@ XTremeCodeEpisode _$XTremeCodeEpisodeFromJson(Map<String, dynamic> json) =>
       containerExtension: json['container_extension'] as String?,
       info:
           XTremeCodeEpisodeInfo.fromJson(json['info'] as Map<String, dynamic>),
-      subtitles: (json['subtitles'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
+      subtitles: stringListFromJson(json['subtitles']),
       customSid: json['custom_sid'] as String?,
       added: dateTimeFromEpochSeconds(json['added']),
       season: dynamicToIntConverter(json['season']),

--- a/lib/src/model/series_info.g.dart
+++ b/lib/src/model/series_info.g.dart
@@ -71,13 +71,15 @@ XTremeCodeInfo _$XTremeCodeInfoFromJson(Map<String, dynamic> json) =>
       lastModified: dateTimeFromEpochSeconds(json['last_modified']),
       rating: dynamicToDoubleConverter(json['rating']),
       rating5based: dynamicToDoubleConverter(json['rating_5based']),
-      backdropPath:
-              stringListFromJson(json['backdrop_path']) ?? const [],
+      backdropPath: json['backdrop_path'] == null
+          ? const []
+          : stringListFromJson(json['backdrop_path']),
       youtubeTrailer: json['youtube_trailer'] as String?,
       episodeRunTime: dynamicToIntConverter(json['episode_run_time']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds:
-              intListFromJson(json['category_ids']) ?? const [],
+      categoryIds: json['category_ids'] == null
+          ? const []
+          : intListFromJson(json['category_ids']),
     );
 
 Map<String, dynamic> _$XTremeCodeInfoToJson(XTremeCodeInfo instance) =>

--- a/lib/src/model/series_items.dart
+++ b/lib/src/model/series_items.dart
@@ -96,7 +96,7 @@ class XTremeCodeSeriesItem {
   final double? rating5based;
 
   /// The backdrop image paths of the series item.
-  @JsonKey(name: 'backdrop_path')
+  @JsonKey(name: 'backdrop_path', fromJson: stringListFromJson)
   final List<String>? backdropPath;
 
   /// The YouTube trailer URL of the series item.
@@ -112,7 +112,7 @@ class XTremeCodeSeriesItem {
   final int? categoryId;
 
   /// The category IDs of the series item.
-  @JsonKey(name: 'category_ids')
+  @JsonKey(name: 'category_ids', fromJson: intListFromJson)
   final List<int>? categoryIds;
 
   /// Converts this [XTremeCodeSeriesItem] instance to a JSON map.

--- a/lib/src/model/series_items.g.dart
+++ b/lib/src/model/series_items.g.dart
@@ -24,15 +24,11 @@ XTremeCodeSeriesItem _$XTremeCodeSeriesItemFromJson(
       lastModified: dateTimeFromEpochSeconds(json['last_modified']),
       rating: dynamicToDoubleConverter(json['rating']),
       rating5based: dynamicToDoubleConverter(json['rating_5based']),
-      backdropPath: (json['backdrop_path'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
+      backdropPath: stringListFromJson(json['backdrop_path']),
       youtubeTrailer: json['youtube_trailer'] as String?,
       episodeRunTime: dynamicToIntConverter(json['episode_run_time']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds: (json['category_ids'] as List<dynamic>?)
-          ?.map((e) => (e as num).toInt())
-          .toList(),
+      categoryIds: intListFromJson(json['category_ids']),
     );
 
 Map<String, dynamic> _$XTremeCodeSeriesItemToJson(

--- a/lib/src/model/user_info.dart
+++ b/lib/src/model/user_info.dart
@@ -62,7 +62,7 @@ class XTremeCodeUserInfo {
   int? maxConnections;
 
   /// The output formats allowed for the user.
-  @JsonKey(name: 'allowed_output_formats')
+  @JsonKey(name: 'allowed_output_formats', fromJson: stringListFromJson)
   List<String>? allowedOutputFormats;
 
   /// Converts this instance into a JSON object.

--- a/lib/src/model/user_info.g.dart
+++ b/lib/src/model/user_info.g.dart
@@ -18,9 +18,8 @@ XTremeCodeUserInfo _$XTremeCodeUserInfoFromJson(Map<String, dynamic> json) =>
       activeCons: dynamicToIntConverter(json['active_cons']),
       createdAt: dateTimeFromEpochSeconds(json['created_at']),
       maxConnections: dynamicToIntConverter(json['max_connections']),
-      allowedOutputFormats: (json['allowed_output_formats'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
+      allowedOutputFormats:
+          stringListFromJson(json['allowed_output_formats']),
     );
 
 Map<String, dynamic> _$XTremeCodeUserInfoToJson(XTremeCodeUserInfo instance) =>

--- a/lib/src/model/user_info.g.dart
+++ b/lib/src/model/user_info.g.dart
@@ -18,8 +18,7 @@ XTremeCodeUserInfo _$XTremeCodeUserInfoFromJson(Map<String, dynamic> json) =>
       activeCons: dynamicToIntConverter(json['active_cons']),
       createdAt: dateTimeFromEpochSeconds(json['created_at']),
       maxConnections: dynamicToIntConverter(json['max_connections']),
-      allowedOutputFormats:
-          stringListFromJson(json['allowed_output_formats']),
+      allowedOutputFormats: stringListFromJson(json['allowed_output_formats']),
     );
 
 Map<String, dynamic> _$XTremeCodeUserInfoToJson(XTremeCodeUserInfo instance) =>

--- a/lib/src/model/vod_info.dart
+++ b/lib/src/model/vod_info.dart
@@ -132,7 +132,7 @@ class XTremeCodeInfoVod {
   final String? genre;
 
   /// The backdrop images of the movie.
-  @JsonKey(name: 'backdrop_path')
+  @JsonKey(name: 'backdrop_path', fromJson: stringListFromJson)
   final List<String>? backdropPath;
 
   /// The duration of the movie in seconds.
@@ -203,7 +203,7 @@ class XTremeCodeMovieData {
   final int? categoryId;
 
   /// The IDs of the categories the movie belongs to.
-  @JsonKey(name: 'category_ids')
+  @JsonKey(name: 'category_ids', fromJson: intListFromJson)
   final List<int>? categoryIds;
 
   /// The container extension of the movie.

--- a/lib/src/model/vod_info.g.dart
+++ b/lib/src/model/vod_info.g.dart
@@ -43,9 +43,7 @@ XTremeCodeInfoVod _$XTremeCodeInfoVodFromJson(Map<String, dynamic> json) =>
           dynamicToIntConverter(json['rating_count_kinopoisk']),
       country: json['country'] as String?,
       genre: json['genre'] as String?,
-      backdropPath: (json['backdrop_path'] as List<dynamic>?)
-          ?.map((e) => e as String)
-          .toList(),
+      backdropPath: stringListFromJson(json['backdrop_path']),
       durationSecs: dynamicToIntConverter(json['duration_secs']),
       duration: json['duration'] as String?,
       bitrate: dynamicToIntConverter(json['bitrate']),
@@ -94,9 +92,7 @@ XTremeCodeMovieData _$XTremeCodeMovieDataFromJson(Map<String, dynamic> json) =>
       year: json['year'] as String?,
       added: dateTimeFromEpochSeconds(json['added']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds: (json['category_ids'] as List<dynamic>?)
-          ?.map((e) => (e as num).toInt())
-          .toList(),
+      categoryIds: intListFromJson(json['category_ids']),
       containerExtension: json['container_extension'] as String,
       customSid: json['custom_sid'] as String?,
       directSource: json['direct_source'] as String?,

--- a/lib/src/model/vod_items.dart
+++ b/lib/src/model/vod_items.dart
@@ -71,7 +71,7 @@ class XTremeCodeVodItem {
   final int? categoryId;
 
   /// The IDs of the categories the VOD item belongs to.
-  @JsonKey(name: 'category_ids')
+  @JsonKey(name: 'category_ids', fromJson: intListFromJson)
   final List<int>? categoryIds;
 
   /// The container extension of the VOD item.

--- a/lib/src/model/vod_items.g.dart
+++ b/lib/src/model/vod_items.g.dart
@@ -19,9 +19,7 @@ XTremeCodeVodItem _$XTremeCodeVodItemFromJson(Map<String, dynamic> json) =>
       rating5based: dynamicToDoubleConverter(json['rating_5based']),
       added: dateTimeFromEpochSeconds(json['added']),
       categoryId: dynamicToIntConverter(json['category_id']),
-      categoryIds: (json['category_ids'] as List<dynamic>?)
-          ?.map((e) => (e as num).toInt())
-          .toList(),
+      categoryIds: intListFromJson(json['category_ids']),
       containerExtension: json['container_extension'] as String?,
       customSid: json['custom_sid'] as String?,
       directSource: json['direct_source'] as String?,

--- a/lib/src/utils/json_helper.dart
+++ b/lib/src/utils/json_helper.dart
@@ -72,3 +72,50 @@ double? dynamicToDoubleConverter(dynamic json) {
   }
   return null;
 }
+
+/// Converts a dynamic json value to a list of strings.
+///
+/// If [json] is `null`, `null` is returned. Any `null` items within the list
+/// are skipped. Non-string values are converted using `toString()`.
+List<String>? stringListFromJson(dynamic json) {
+  if (json == null) {
+    return null;
+  }
+
+  if (json is Iterable) {
+    final result = <String>[];
+    for (final dynamic item in json) {
+      if (item == null) {
+        continue;
+      }
+      result.add(item.toString());
+    }
+    return result;
+  }
+
+  return [json.toString()];
+}
+
+/// Converts a dynamic json value to a list of integers.
+///
+/// If [json] is `null`, `null` is returned. Any item that cannot be converted
+/// to an integer is skipped.
+List<int>? intListFromJson(dynamic json) {
+  if (json == null) {
+    return null;
+  }
+
+  if (json is Iterable) {
+    final result = <int>[];
+    for (final dynamic item in json) {
+      final value = dynamicToIntConverter(item);
+      if (value != null) {
+        result.add(value);
+      }
+    }
+    return result;
+  }
+
+  final singleValue = dynamicToIntConverter(json);
+  return singleValue == null ? null : <int>[singleValue];
+}

--- a/test/model/livestream_items_test.dart
+++ b/test/model/livestream_items_test.dart
@@ -57,5 +57,15 @@ void main() {
       expect(item.tvArchiveDuration, 0);
       expect(item.categoryId, 1);
     });
+
+    test('list can contain nulls', () {
+      final jsonWithNull = {
+        ...mockJsonString,
+        'category_ids': [1, null],
+      };
+
+      final item = XTremeCodeLiveStreamItem.fromJson(jsonWithNull);
+      expect(item.categoryIds, [1]);
+    });
   });
 }

--- a/test/model/series_info_test.dart
+++ b/test/model/series_info_test.dart
@@ -196,5 +196,30 @@ void main() {
       expect(episode.added, dateTimeFromEpochSeconds(1678845306));
       expect(episode.season, 1);
     });
+
+    test('lists can contain nulls', () {
+      final jsonWithNull = {
+        ...mockJsonString,
+        'info': {
+          ...?mockJsonString['info'],
+          'backdrop_path': ['https://someurl.com/backdrop.jpg', null],
+          'category_ids': [26, null],
+        },
+        'episodes': {
+          '1': [
+            {
+              ...mockJsonString['episodes']!['1']![0],
+              'subtitles': ['English', null],
+            },
+          ],
+        },
+      };
+
+      final item = XTremeCodeSeriesInfo.fromJson(jsonWithNull);
+      expect(item.info.backdropPath, ['https://someurl.com/backdrop.jpg']);
+      expect(item.info.categoryIds, [26]);
+      final episode = item.episodes?['1']?[0];
+      expect(episode?.subtitles, ['English']);
+    });
   });
 }

--- a/test/model/series_info_test.dart
+++ b/test/model/series_info_test.dart
@@ -199,16 +199,17 @@ void main() {
 
     test('lists can contain nulls', () {
       final jsonWithNull = {
-        ...mockJsonString,
+        ...mockJsonString as Map<String, dynamic>,
         'info': {
-          ...?mockJsonString['info'],
+          ...(mockJsonString['info']! as Map<String, dynamic>),
           'backdrop_path': ['https://someurl.com/backdrop.jpg', null],
           'category_ids': [26, null],
         },
         'episodes': {
           '1': [
             {
-              ...mockJsonString['episodes']!['1']![0],
+              ...((mockJsonString['episodes']! as Map<String, dynamic>)['1']!
+                  as List)[0] as Map<String, dynamic>,
               'subtitles': ['English', null],
             },
           ],

--- a/test/model/series_items_test.dart
+++ b/test/model/series_items_test.dart
@@ -77,5 +77,17 @@ void main() {
       expect(item.episodeRunTime, 42);
       expect(item.categoryId, 141);
     });
+
+    test('lists can contain nulls', () {
+      final jsonWithNull = {
+        ...mockJsonString,
+        'backdrop_path': ['https://someurl.com/backdrop.jpg', null],
+        'category_ids': [141, null],
+      };
+
+      final item = XTremeCodeSeriesItem.fromJson(jsonWithNull);
+      expect(item.backdropPath, ['https://someurl.com/backdrop.jpg']);
+      expect(item.categoryIds, [141]);
+    });
   });
 }

--- a/test/model/user_info_test.dart
+++ b/test/model/user_info_test.dart
@@ -74,5 +74,12 @@ void main() {
       expect(item.maxConnections, 1);
       expect(item.allowedOutputFormats, ['m3u8', 'ts', 'rtmp']);
     });
+
+    test('list can contain nulls', () {
+      mockJsonString['allowed_output_formats'] = ['m3u8', null, 'ts'];
+
+      final item = XTremeCodeUserInfo.fromJson(mockJsonString);
+      expect(item.allowedOutputFormats, ['m3u8', 'ts']);
+    });
   });
 }

--- a/test/model/vod_info_test.dart
+++ b/test/model/vod_info_test.dart
@@ -131,5 +131,23 @@ void main() {
       expect(item.movieData.added, dateTimeFromEpochSeconds(1705050604));
       expect(item.movieData.categoryId, 295);
     });
+
+    test('lists can contain nulls', () {
+      final jsonWithNull = {
+        ...mockJsonString,
+        'info': {
+          ...?mockJsonString['info'],
+          'backdrop_path': ['https://someurl.com', null],
+        },
+        'movie_data': {
+          ...?mockJsonString['movie_data'],
+          'category_ids': [295, null],
+        },
+      };
+
+      final item = XTremeCodeVodInfo.fromJson(jsonWithNull);
+      expect(item.info.backdropPath, ['https://someurl.com']);
+      expect(item.movieData.categoryIds, [295]);
+    });
   });
 }

--- a/test/model/vod_items_test.dart
+++ b/test/model/vod_items_test.dart
@@ -61,5 +61,15 @@ void main() {
       expect(item.added, dateTimeFromEpochSeconds(1705390203));
       expect(item.categoryId, 295);
     });
+
+    test('list can contain nulls', () {
+      final jsonWithNull = {
+        ...mockJsonString,
+        'category_ids': [295, null],
+      };
+
+      final item = XTremeCodeVodItem.fromJson(jsonWithNull);
+      expect(item.categoryIds, [295]);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- parse list values with `stringListFromJson` and `intListFromJson`
- handle lists with null entries in models
- update generated models
- test parsing when lists contain null values

## Testing
- `dart run build_runner build --delete-conflicting-outputs` *(fails: dart not found)*
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840597d51b8832c9be448e7187b6ad3